### PR TITLE
Q: How to get system uptime?

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ gì có thể xảy ra (hint: df -i`)
   đang làm cho họ?
 - Bạn đã từng đọc bài nào do `Phusion Passenger` viết chưa? Bài đó như thế nào
   và bạn đã học được gì từ bài đó?
+- Làm thế nào để biết hệ thống đã chạy được bao lâu rồi? (aka `uptime`)


### PR DESCRIPTION
This is an easy question at first. But then you will know that
inside a docker container, /proc/uptime only provides host information.
You will not be able to know how long your container is up.

The you will try to use some command like "ps" to help.

Then you know that "ps" command does not exist anywhere in your
container.

So this question can simply kill you. Be careful